### PR TITLE
Implement project mapping API

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,7 @@ This project synchronizes issues between GitLab and JIRA using a Quarkus backend
 
 The project structure follows a standard Quarkus application layout and requires Java 21 and Maven.
 
+## Current API
+
+- `GET /api/projects` – list configured project mappings
+- `POST /api/projects` – add a new project mapping

--- a/src/main/java/com/example/model/ProjectMapping.java
+++ b/src/main/java/com/example/model/ProjectMapping.java
@@ -1,0 +1,43 @@
+package com.example.model;
+
+import jakarta.json.bind.annotation.JsonbProperty;
+
+public class ProjectMapping {
+    private static long idCounter = 0;
+
+    private long id;
+    @JsonbProperty("gitlab_project_id")
+    private String gitlabProjectId;
+    @JsonbProperty("jira_project_key")
+    private String jiraProjectKey;
+
+    public ProjectMapping() {
+        // Default constructor for JSON-B
+    }
+
+    public ProjectMapping(String gitlabProjectId, String jiraProjectKey) {
+        this.id = ++idCounter;
+        this.gitlabProjectId = gitlabProjectId;
+        this.jiraProjectKey = jiraProjectKey;
+    }
+
+    public long getId() {
+        return id;
+    }
+
+    public String getGitlabProjectId() {
+        return gitlabProjectId;
+    }
+
+    public void setGitlabProjectId(String gitlabProjectId) {
+        this.gitlabProjectId = gitlabProjectId;
+    }
+
+    public String getJiraProjectKey() {
+        return jiraProjectKey;
+    }
+
+    public void setJiraProjectKey(String jiraProjectKey) {
+        this.jiraProjectKey = jiraProjectKey;
+    }
+}

--- a/src/main/java/com/example/resource/ProjectResource.java
+++ b/src/main/java/com/example/resource/ProjectResource.java
@@ -1,0 +1,32 @@
+package com.example.resource;
+
+import com.example.model.ProjectMapping;
+import com.example.service.ProjectService;
+import jakarta.inject.Inject;
+import jakarta.ws.rs.Consumes;
+import jakarta.ws.rs.GET;
+import jakarta.ws.rs.POST;
+import jakarta.ws.rs.Path;
+import jakarta.ws.rs.Produces;
+import jakarta.ws.rs.core.MediaType;
+
+import java.util.List;
+
+@Path("/api/projects")
+@Produces(MediaType.APPLICATION_JSON)
+@Consumes(MediaType.APPLICATION_JSON)
+public class ProjectResource {
+
+    @Inject
+    ProjectService service;
+
+    @GET
+    public List<ProjectMapping> list() {
+        return service.list();
+    }
+
+    @POST
+    public ProjectMapping add(ProjectMapping mapping) {
+        return service.add(new ProjectMapping(mapping.getGitlabProjectId(), mapping.getJiraProjectKey()));
+    }
+}

--- a/src/main/java/com/example/service/ProjectService.java
+++ b/src/main/java/com/example/service/ProjectService.java
@@ -1,0 +1,22 @@
+package com.example.service;
+
+import com.example.model.ProjectMapping;
+import jakarta.enterprise.context.ApplicationScoped;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.CopyOnWriteArrayList;
+
+@ApplicationScoped
+public class ProjectService {
+    private final List<ProjectMapping> mappings = new CopyOnWriteArrayList<>();
+
+    public List<ProjectMapping> list() {
+        return Collections.unmodifiableList(mappings);
+    }
+
+    public ProjectMapping add(ProjectMapping mapping) {
+        mappings.add(mapping);
+        return mapping;
+    }
+}

--- a/src/test/java/com/example/resource/ProjectResourceTest.java
+++ b/src/test/java/com/example/resource/ProjectResourceTest.java
@@ -1,0 +1,37 @@
+package com.example.resource;
+
+import io.quarkus.test.junit.QuarkusTest;
+import io.restassured.RestAssured;
+import org.hamcrest.Matchers;
+import org.junit.jupiter.api.Test;
+
+@QuarkusTest
+public class ProjectResourceTest {
+
+    @Test
+    public void testListEmpty() {
+        RestAssured.given()
+            .when().get("/api/projects")
+            .then()
+            .statusCode(200)
+            .body("size()", Matchers.is(0));
+    }
+
+    @Test
+    public void testAddProject() {
+        RestAssured.given()
+            .contentType("application/json")
+            .body("{\"gitlab_project_id\":\"1\", \"jira_project_key\":\"ABC\"}")
+            .when().post("/api/projects")
+            .then()
+            .statusCode(200)
+            .body("gitlab_project_id", Matchers.is("1"))
+            .body("jira_project_key", Matchers.is("ABC"));
+
+        RestAssured.given()
+            .when().get("/api/projects")
+            .then()
+            .statusCode(200)
+            .body("size()", Matchers.is(1));
+    }
+}


### PR DESCRIPTION
## Summary
- implement a simple `ProjectService` to keep mappings in memory
- expose `/api/projects` endpoint to list and add mappings
- cover the endpoint with tests
- document the new API in the README

## Testing
- `mvn test -q` *(fails: could not resolve Maven dependencies)*

------
https://chatgpt.com/codex/tasks/task_e_686439bf75cc8323b9b8d7582ded0df6