### PR TITLE
Add DB persistence

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,6 +40,14 @@
         </dependency>
         <dependency>
             <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-hibernate-orm-panache</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
+            <artifactId>quarkus-jdbc-h2</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>io.quarkus</groupId>
             <artifactId>quarkus-junit5</artifactId>
             <scope>test</scope>
         </dependency>

--- a/src/main/java/com/gitlabjiralink/api/IssueLink.java
+++ b/src/main/java/com/gitlabjiralink/api/IssueLink.java
@@ -1,3 +1,10 @@
 package com.gitlabjiralink.api;
 
-public record IssueLink(Long gitlabIssueId, String jiraIssueKey) {}
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class IssueLink extends PanacheEntity {
+    public Long gitlabIssueId;
+    public String jiraIssueKey;
+}

--- a/src/main/java/com/gitlabjiralink/api/IssueRepository.java
+++ b/src/main/java/com/gitlabjiralink/api/IssueRepository.java
@@ -1,0 +1,8 @@
+package com.gitlabjiralink.api;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class IssueRepository implements PanacheRepository<IssueLink> {
+}

--- a/src/main/java/com/gitlabjiralink/api/IssueService.java
+++ b/src/main/java/com/gitlabjiralink/api/IssueService.java
@@ -1,20 +1,23 @@
 package com.gitlabjiralink.api;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @ApplicationScoped
 public class IssueService {
-    private final List<IssueLink> links = new CopyOnWriteArrayList<>();
+
+    @Inject
+    IssueRepository repository;
 
     public List<IssueLink> list() {
-        return new ArrayList<>(links);
+        return repository.listAll();
     }
 
+    @Transactional
     public void add(IssueLink link) {
-        links.add(link);
+        repository.persist(link);
     }
 }

--- a/src/main/java/com/gitlabjiralink/api/LogEntry.java
+++ b/src/main/java/com/gitlabjiralink/api/LogEntry.java
@@ -1,5 +1,11 @@
 package com.gitlabjiralink.api;
 
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
 import java.time.Instant;
 
-public record LogEntry(Instant timestamp, String message) {}
+@Entity
+public class LogEntry extends PanacheEntity {
+    public Instant timestamp;
+    public String message;
+}

--- a/src/main/java/com/gitlabjiralink/api/LogRepository.java
+++ b/src/main/java/com/gitlabjiralink/api/LogRepository.java
@@ -1,0 +1,8 @@
+package com.gitlabjiralink.api;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class LogRepository implements PanacheRepository<LogEntry> {
+}

--- a/src/main/java/com/gitlabjiralink/api/LogService.java
+++ b/src/main/java/com/gitlabjiralink/api/LogService.java
@@ -1,21 +1,27 @@
 package com.gitlabjiralink.api;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CopyOnWriteArrayList;
 
 @ApplicationScoped
 public class LogService {
-    private final List<LogEntry> logs = new CopyOnWriteArrayList<>();
+
+    @Inject
+    LogRepository repository;
 
     public List<LogEntry> list() {
-        return new ArrayList<>(logs);
+        return repository.listAll();
     }
 
+    @Transactional
     public void log(String message) {
-        logs.add(new LogEntry(Instant.now(), message));
+        LogEntry entry = new LogEntry();
+        entry.timestamp = Instant.now();
+        entry.message = message;
+        repository.persist(entry);
     }
 }

--- a/src/main/java/com/gitlabjiralink/api/ProjectMapping.java
+++ b/src/main/java/com/gitlabjiralink/api/ProjectMapping.java
@@ -1,3 +1,10 @@
 package com.gitlabjiralink.api;
 
-public record ProjectMapping(Long id, String gitlabProject, String jiraProject) {}
+import io.quarkus.hibernate.orm.panache.PanacheEntity;
+import jakarta.persistence.Entity;
+
+@Entity
+public class ProjectMapping extends PanacheEntity {
+    public String gitlabProject;
+    public String jiraProject;
+}

--- a/src/main/java/com/gitlabjiralink/api/ProjectRepository.java
+++ b/src/main/java/com/gitlabjiralink/api/ProjectRepository.java
@@ -1,0 +1,8 @@
+package com.gitlabjiralink.api;
+
+import io.quarkus.hibernate.orm.panache.PanacheRepository;
+import jakarta.enterprise.context.ApplicationScoped;
+
+@ApplicationScoped
+public class ProjectRepository implements PanacheRepository<ProjectMapping> {
+}

--- a/src/main/java/com/gitlabjiralink/api/ProjectResource.java
+++ b/src/main/java/com/gitlabjiralink/api/ProjectResource.java
@@ -24,7 +24,7 @@ public class ProjectResource {
     @POST
     public Response add(ProjectMapping mapping) {
         ProjectMapping stored = service.add(mapping);
-        return Response.created(URI.create("/api/projects/" + stored.id())).entity(stored).build();
+        return Response.created(URI.create("/api/projects/" + stored.id)).entity(stored).build();
     }
 
     @PUT

--- a/src/main/java/com/gitlabjiralink/api/ProjectService.java
+++ b/src/main/java/com/gitlabjiralink/api/ProjectService.java
@@ -1,44 +1,44 @@
 package com.gitlabjiralink.api;
 
 import jakarta.enterprise.context.ApplicationScoped;
+import jakarta.inject.Inject;
+import jakarta.transaction.Transactional;
 
-import java.util.ArrayList;
-import java.util.Collections;
 import java.util.List;
-import java.util.Map;
-import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.atomic.AtomicLong;
 
 @ApplicationScoped
 public class ProjectService {
-    private final Map<Long, ProjectMapping> projects = new ConcurrentHashMap<>();
-    private final AtomicLong counter = new AtomicLong(1);
+
+    @Inject
+    ProjectRepository repository;
 
     public List<ProjectMapping> list() {
-        return new ArrayList<>(projects.values());
+        return repository.listAll();
     }
 
+    @Transactional
     public ProjectMapping add(ProjectMapping mapping) {
-        long id = counter.getAndIncrement();
-        ProjectMapping stored = new ProjectMapping(id, mapping.gitlabProject(), mapping.jiraProject());
-        projects.put(id, stored);
-        return stored;
+        repository.persist(mapping);
+        return mapping;
     }
 
+    @Transactional
     public ProjectMapping update(Long id, ProjectMapping mapping) {
-        if (!projects.containsKey(id)) {
+        ProjectMapping existing = repository.findById(id);
+        if (existing == null) {
             return null;
         }
-        ProjectMapping updated = new ProjectMapping(id, mapping.gitlabProject(), mapping.jiraProject());
-        projects.put(id, updated);
-        return updated;
+        existing.gitlabProject = mapping.gitlabProject;
+        existing.jiraProject = mapping.jiraProject;
+        return existing;
     }
 
+    @Transactional
     public boolean delete(Long id) {
-        return projects.remove(id) != null;
+        return repository.deleteById(id);
     }
 
     public ProjectMapping find(Long id) {
-        return projects.get(id);
+        return repository.findById(id);
     }
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+quarkus.datasource.db-kind=h2
+quarkus.datasource.jdbc.url=jdbc:h2:mem:gitlabjiralink;DB_CLOSE_DELAY=-1
+quarkus.datasource.username=user
+quarkus.datasource.password=pass
+quarkus.hibernate-orm.database.generation=drop-and-create

--- a/src/test/java/com/gitlabjiralink/api/ProjectResourceTest.java
+++ b/src/test/java/com/gitlabjiralink/api/ProjectResourceTest.java
@@ -16,7 +16,7 @@ class ProjectResourceTest {
         long id = 
             given()
                 .contentType(ContentType.JSON)
-                .body(new ProjectMapping(null, "gitlab", "jira"))
+                .body(makeMapping(null, "gitlab", "jira"))
             .when()
                 .post("/api/projects")
             .then()
@@ -32,7 +32,7 @@ class ProjectResourceTest {
         // update
         given()
             .contentType(ContentType.JSON)
-            .body(new ProjectMapping(id, "g", "j"))
+            .body(makeMapping(id, "g", "j"))
         .when()
             .put("/api/projects/" + id)
         .then()
@@ -52,5 +52,13 @@ class ProjectResourceTest {
             .delete("/api/projects/" + id)
         .then()
             .statusCode(404);
+    }
+
+    private static ProjectMapping makeMapping(Long id, String gitlab, String jira) {
+        ProjectMapping m = new ProjectMapping();
+        m.id = id;
+        m.gitlabProject = gitlab;
+        m.jiraProject = jira;
+        return m;
     }
 }


### PR DESCRIPTION
## Summary
- use Hibernate ORM Panache entities for issue links, project mappings and log entries
- persist data through Panache repositories and services
- configure in-memory H2 datasource
- adapt REST resource and tests
- add Panache and JDBC dependencies

## Testing
- `./mvnw -q test` *(fails: Network is unreachable)*

------
https://chatgpt.com/codex/tasks/task_e_6864472468e8832395f980cba5a0f9de