### PR TITLE
Increase coverage

### DIFF
--- a/src/test/java/com/gitlabjiralink/api/ProjectResourceTest.java
+++ b/src/test/java/com/gitlabjiralink/api/ProjectResourceTest.java
@@ -52,6 +52,15 @@ class ProjectResourceTest {
             .delete("/api/projects/" + id)
         .then()
             .statusCode(404);
+
+        // update not found
+        given()
+            .contentType(ContentType.JSON)
+            .body(makeMapping(id, "a", "b"))
+        .when()
+            .put("/api/projects/" + id)
+        .then()
+            .statusCode(404);
     }
 
     private static ProjectMapping makeMapping(Long id, String gitlab, String jira) {

--- a/src/test/java/com/gitlabjiralink/api/ProjectServiceTest.java
+++ b/src/test/java/com/gitlabjiralink/api/ProjectServiceTest.java
@@ -16,13 +16,13 @@ class ProjectServiceTest {
 
     @Test
     void testAddUpdateDelete() {
-        assertEquals(0, repository.count());
+        long before = repository.count();
         ProjectMapping mapping = new ProjectMapping();
         mapping.gitlabProject = "g1";
         mapping.jiraProject = "j1";
         ProjectMapping stored = service.add(mapping);
         assertNotNull(stored.id);
-        assertEquals(1, repository.count());
+        assertEquals(before + 1, repository.count());
 
         ProjectMapping update = new ProjectMapping();
         update.gitlabProject = "g2";
@@ -32,7 +32,7 @@ class ProjectServiceTest {
         assertEquals("g2", updated.gitlabProject);
 
         assertTrue(service.delete(stored.id));
-        assertEquals(0, repository.count());
+        assertEquals(before, repository.count());
     }
 
     @Test
@@ -41,5 +41,17 @@ class ProjectServiceTest {
         update.gitlabProject = "x";
         update.jiraProject = "y";
         assertNull(service.update(999L, update));
+    }
+
+    @Test
+    void testFind() {
+        ProjectMapping mapping = new ProjectMapping();
+        mapping.gitlabProject = "g";
+        mapping.jiraProject = "j";
+        ProjectMapping stored = service.add(mapping);
+        ProjectMapping found = service.find(stored.id);
+        assertNotNull(found);
+        assertEquals("g", found.gitlabProject);
+        assertNull(service.find(999L));
     }
 }


### PR DESCRIPTION
## Summary
- add additional test case to cover update-not-found behavior
- extend project service tests to exercise the `find` method

## Testing
- `mvn -q test`

------
https://chatgpt.com/codex/tasks/task_e_686458dead5883238509d359ad215059